### PR TITLE
Fix : UI articles on both admin and user side

### DIFF
--- a/src/app/admin/articles/[slug]/page.tsx
+++ b/src/app/admin/articles/[slug]/page.tsx
@@ -37,13 +37,12 @@ export default async function AdminArticleView({ params }: PageProps) {
   return (
     <div className="min-h-screen bg-gray-50">
       <AdminHeader />
-      
-      <div className="max-w-6xl mx-auto p-6">
+      <div className="bg-gray-50 max-w-4xl mx-auto p-6">
         {/* Admin Header with Controls */}
-        <div className="flex justify-between items-center mb-6">
+        <div className="flex justify-between items-center mb-3 mt-6">
           <Link 
             href="/admin/dashboard" 
-            className="text-blue-600 hover:text-blue-800 font-medium"
+            className="text-blue-600 hover:text-blue-800 text-xl"
           >
             ← Back to Dashboard
           </Link>
@@ -72,7 +71,7 @@ export default async function AdminArticleView({ params }: PageProps) {
         </div>
 
         {/* Article Content using your existing ArticleRenderer */}
-        <div className="bg-white rounded-lg shadow-sm overflow-hidden">
+        <div className="bg-gray-50 rounded-lg overflow-hidden">
           <ArticleRenderer article={article} />
         </div>
 

--- a/src/app/admin/articles/[slug]/preview/page.tsx
+++ b/src/app/admin/articles/[slug]/preview/page.tsx
@@ -84,9 +84,9 @@ export default function PreviewPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 -mt-16">
       <div className="bg-yellow-100 border-b-2 border-yellow-400 p-4 text-center sticky top-0 z-50">
-        <div className="max-w-4xl mx-auto flex justify-between items-center">
+        <div className="max-w-3xl mx-auto flex justify-between items-center">
           <p className="text-yellow-900 font-semibold">
             🔍 Preview Mode - This is how your article will look when published
           </p>

--- a/src/app/articles/[category]/[subcategory]/[slug]/page.tsx
+++ b/src/app/articles/[category]/[subcategory]/[slug]/page.tsx
@@ -71,18 +71,18 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
     .limit(10);
 
   return (
-    <>
+    <div className="bg-gray-50 min-h-screen">
       <Header />
-      <div className="flex max-w-[1400px] mx-auto px-6 py-12 gap-6 bg-gray-50 min-h-screen">
+      <div className="flex max-w-[1400px] mx-auto px-6 gap-6 bg-gray-50 min-h-screen">
         {/* Left Ad */}
         <aside className="hidden xl:block w-64 flex-shrink-0">
-          <div className="sticky top-6 bg-gray-200 rounded-lg p-8 h-[600px] flex items-center justify-center">
+          <div className="sticky top-24 bg-gray-200 rounded-lg p-8 h-[600px] flex items-center justify-center">
             <span className="text-gray-500 font-semibold">Ads Here</span>
           </div>
         </aside>
 
         {/* Main Article Content */}
-        <main className="flex-1 bg-white rounded-lg shadow-md p-6">
+        <main className="flex-1 bg-gray-50 rounded-lg p-6">
           <ArticleRenderer article={article} />
           {suggestedArticles && suggestedArticles.length > 0 && (
             <SuggestedArticlesCarousel
@@ -94,13 +94,13 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
 
         {/* Right Ad */}
         <aside className="hidden xl:block w-64 flex-shrink-0">
-          <div className="sticky top-6 bg-gray-200 rounded-lg p-8 h-[600px] flex items-center justify-center">
+          <div className="sticky top-24 bg-gray-200 rounded-lg p-8 h-[600px] flex items-center justify-center">
             <span className="text-gray-500 font-semibold">Ads Here</span>
           </div>
         </aside>
       </div>
       <Footer />
-    </>
+    </div>
   );
 }
 

--- a/src/app/components/ArticleRenderer.tsx
+++ b/src/app/components/ArticleRenderer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React from "react";
+import React, { useState, useEffect } from "react";
+import { ChevronUpIcon } from 'lucide-react';
 
 type Article = {
   id: string;
@@ -29,6 +30,20 @@ const COMPONENT_TYPES = {
 };
 
 export default function ArticleRenderer({ article }: ArticleRendererProps) {
+  const [isScrolled, setIsScrolled] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+
+    const handleScroll = () => {
+      setIsScrolled(window.scrollY > 200);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
   let editorData;
   try {
     editorData =
@@ -79,7 +94,7 @@ export default function ArticleRenderer({ article }: ArticleRendererProps) {
         return (
           <div 
             key={index}
-            className="prose prose-lg max-w-none mb-6"
+            className="max-w-none mb-6"
             dangerouslySetInnerHTML={{ __html: props.content || '' }}
           />
         );
@@ -88,7 +103,7 @@ export default function ArticleRenderer({ article }: ArticleRendererProps) {
         return (
           <div
             key={index}
-            className="prose prose-lg max-w-none mb-6"
+            className="max-w-none mb-6"
             dangerouslySetInnerHTML={{ __html: props.content || "" }}
           />
         );
@@ -106,7 +121,7 @@ export default function ArticleRenderer({ article }: ArticleRendererProps) {
         
         if (hasCustomDimensions) {
           return (
-            <figure key={index} className="mb-8 flex justify-center">
+            <figure key={index} className="mb-8 flex flex-col items-center">
               {props.src && (
                 <div style={{ maxWidth: '100%', display: 'inline-block' }}>
                   <img
@@ -114,7 +129,7 @@ export default function ArticleRenderer({ article }: ArticleRendererProps) {
                     alt={props.alt || ""}
                     width={props.width}
                     height={props.height}
-                    className="rounded-xl shadow-lg"
+                    className="rounded-xl"
                     style={{ 
                       display: 'block',
                       maxWidth: '100%',
@@ -139,7 +154,7 @@ export default function ArticleRenderer({ article }: ArticleRendererProps) {
               <img
                 src={props.src}
                 alt={props.alt || ""}
-                className="w-full rounded-xl object-cover shadow-lg"
+                className="w-full rounded-xl object-cover"
               />
             )}
             {props.caption && (
@@ -179,15 +194,28 @@ export default function ArticleRenderer({ article }: ArticleRendererProps) {
     }
   };
 
+  const handleScrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+
   return (
-    <article className="max-w-4xl mx-auto px-6 py-2 bg-white">
-      <a
-        href="/articles"
-        className="block text-blue-600 hover:text-blue-800 font-medium transition-colors mb-6"
-      >
-        &larr; Back to Articles
-      </a>
-      <header className="mb-12">
+    <article className="max-w-3xl mx-auto px-6 py-2 bg-gray-50">
+      {mounted && (
+        <div className="fixed bottom-0 right-4 pb-6">
+          <button 
+            className={`shadow-xl rounded-full px-2 py-2 bg-white transition-all hover:scale-105 ${
+              isScrolled ? 'opacity-100' : 'opacity-0 pointer-events-none'
+            }`}
+            onClick={ handleScrollToTop }
+          >
+            <ChevronUpIcon
+              className="h-10 w-10 text-[var(--custom-orange)] cursor-pointer"
+            />
+          </button>
+        </div>
+      )}
+      <header className="mb-12 mt-10">
         {article.thumbnail_url && (
           <img
             src={article.thumbnail_url}
@@ -225,7 +253,7 @@ export default function ArticleRenderer({ article }: ArticleRendererProps) {
         </div>
       </header>
 
-      <div className="prose prose-lg max-w-none">
+      <div className="max-w-none">
         {contentArray.length > 0 ? (
           contentArray.map((component: any, index: number) =>
             renderComponent(component, index)


### PR DESCRIPTION
Implemented the Following:
- Proper layout of images and its caption (by default, now centered on the page no matter the size)
- Added button to go back to topmost of the page
- Fixed gap of ads on the user side articles
- Removed duplicate back to dashboard/article